### PR TITLE
Change postRegister method to private static

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -49,7 +49,7 @@ export class Kit {
         });
     }
 
-    static postRegister(pPlugin: /*KitPlugin*/any): void {
+    private static postRegister(pPlugin: /*KitPlugin*/any): void {
         Object.freeze(pPlugin);
         const listener: Listener = (pEvent: EmitterEvent) => {
             Kit.emit(pEvent);


### PR DESCRIPTION
Update the postRegister method to be private static, enhancing encapsulation within the Kit class.